### PR TITLE
Make Vimeo video have fluid width

### DIFF
--- a/source/_video.html.haml
+++ b/source/_video.html.haml
@@ -1,1 +1,2 @@
-<iframe src="//player.vimeo.com/video/88610240" width="800" height="450" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+.player-wrapper
+  <iframe src="//player.vimeo.com/video/88610240" width="800" height="450" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/source/stylesheets/_video.scss
+++ b/source/stylesheets/_video.scss
@@ -1,3 +1,19 @@
 .video {
-  text-align: center;
+  max-width: 800px;
+  margin: 0 auto;
+
+  .player-wrapper {
+    height: 0;
+    margin: 0 auto;
+    padding-bottom: 56.25%; /* 16:9 */
+    position: relative;
+
+    iframe {
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
+  }
 }


### PR DESCRIPTION
I've been snapshotting this site using Diffux [1] and noticed that the
Vimeo video on the start page was overflowing the width on mobile. To
make this work better responsively, I applied a technique described
here:
http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php

The basic trick is to create a wrapping elemnt and use padding to make
its width:height ratio 16:9, and then absolutely positioning the iframe
inside the wrapper and apply a 100% width and height.

Snapshot of the page before:
https://dl.dropboxusercontent.com/u/36290073/campsass_diffux_before.png

...and after:
https://dl.dropboxusercontent.com/u/36290073/campsass_diffux_after.png

(Note that these snapshots are done using PhantomJS, so they will not
look the same as on a mobile).

[1] https://github.com/trotzig/diffux
